### PR TITLE
 Security: CWE-78 Command Injection - False Positive Review

### DIFF
--- a/adapters/base_embeddings.py
+++ b/adapters/base_embeddings.py
@@ -36,6 +36,8 @@ class ModelAdapter(dl.BaseModelAdapter):
         if encoding_format is None:
             logger.warning("encoding_format not set. Using default model value")
 
+        if not isinstance(text, (str, list)):
+            raise TypeError(f"Expected text input to be str or list, got {type(text).__name__}")
         response = self.client.embeddings.create(
             input=text,
             model=model_name,


### PR DESCRIPTION
## Security: Checkmarx SAST CWE-78 Command Injection — False Positive Review

### Finding
Checkmarx SAST flagged **1 Critical** Command Injection (CWE-78):

| File | Line | Variable | Actual Operation |
|------|------|----------|-----------------|
| `adapters/base_embeddings.py` | 40 | `text` | `self.client.embeddings.create(input=text, ...)` — OpenAI SDK API call |

### Analysis
This is a **false positive**. The `text` variable is passed to the OpenAI Python SDK's `embeddings.create()` method, which makes an HTTPS API request to Databricks. This is not a shell command or OS-level process execution.

The `text` value originates from either:
- A string passed directly to the `embed()` method
- Content extracted from a Dataloop `PromptItem`

There is no `subprocess`, `os.system`, `os.popen`, `exec`, or `eval` in this file.

### Changes
Added **input type validation** before the API call as defensive hardening:
- Validates `text` is a `str` or `list` before passing to the embeddings API
- Raises `TypeError` if an unexpected type is provided

This does not change functionality but adds an explicit type safety check at the flagged location.
